### PR TITLE
Improve 3D mind map visualization for better readability

### DIFF
--- a/src/components/MindMap3D/Node.js
+++ b/src/components/MindMap3D/Node.js
@@ -14,11 +14,11 @@ export default function Node({ node, onClick, onHover }) {
   const meshRef = useRef();
   const [hovered, setHovered] = useState(false);
 
-  // Calculate node size based on connections (min 0.3, max 1.5)
+  // Calculate node size based on connections (min 0.8, max 3.0)
   const size = useMemo(() => {
-    const baseSize = 0.3;
-    const scaleFactor = 0.05;
-    return Math.min(baseSize + node.connections * scaleFactor, 1.5);
+    const baseSize = 0.8;
+    const scaleFactor = 0.08;
+    return Math.min(baseSize + node.connections * scaleFactor, 3.0);
   }, [node.connections]);
 
   const color = CATEGORY_COLORS[node.category] || CATEGORY_COLORS.default;
@@ -64,16 +64,20 @@ export default function Node({ node, onClick, onHover }) {
 
       {/* Label (only show on hover) */}
       {hovered && (
-        <Html distanceFactor={10} position={[0, size + 0.5, 0]}>
+        <Html distanceFactor={0.5} position={[0, size + 1.5, 0]}>
           <div
             style={{
-              background: 'rgba(0, 0, 0, 0.8)',
-              color: 'white',
-              padding: '4px 8px',
-              borderRadius: '4px',
-              fontSize: '12px',
+              background: color,
+              color: '#000000',
+              padding: '24px 48px',
+              borderRadius: '16px',
+              fontSize: '96px',
+              fontWeight: '800',
               whiteSpace: 'nowrap',
               pointerEvents: 'none',
+              border: `6px solid white`,
+              boxShadow: '0 12px 32px rgba(255, 255, 255, 0.5)',
+              letterSpacing: '2px',
             }}
           >
             {node.label}

--- a/src/components/MindMap3D/index.js
+++ b/src/components/MindMap3D/index.js
@@ -36,7 +36,7 @@ function Scene({ nodes, edges, onNodeClick, hoveredNode, setHoveredNode }) {
       <pointLight position={[-10, -10, -10]} intensity={0.5} />
 
       {/* Stars for space effect */}
-      <Stars radius={300} depth={50} count={5000} factor={4} saturation={0} fade />
+      <Stars radius={300} depth={50} count={2000} factor={2} saturation={0} fade speed={0.5} />
 
       {/* Edges */}
       {edges.map((edge, idx) => {


### PR DESCRIPTION
## Summary
Enhanced the 3D mind map visualization to improve user experience and readability:

- **Larger nodes**: Increased base size from 0.3 to 0.8 and max from 1.5 to 3.0 for better visibility
- **Reduced star background**: Decreased star count and intensity to prevent visual distraction from nodes
- **Enhanced hover labels**: 
  - Dramatically increased text size (96px) with extra bold font
  - High-contrast design: bright category-colored backgrounds with black text
  - White borders and glow effects for visibility against dark space background
  - Improved spacing and positioning

## Changes
- `src/components/MindMap3D/Node.js`: Updated node sizing and hover label styling
- `src/components/MindMap3D/index.js`: Reduced star background intensity

## Testing
- ✅ Tested locally at http://localhost:3000/
- ✅ Nodes are now clearly visible against the background
- ✅ Hover labels are large and easily readable with high contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)