### PR TITLE
Fix client-side tag filtering on garden page

### DIFF
--- a/src/pages/garden/index.astro
+++ b/src/pages/garden/index.astro
@@ -285,3 +285,51 @@ const allTags = [...new Set(blogEntries.flatMap(entry => entry.data.tags))].sort
     }
   }
 </style>
+
+<script>
+  // Client-side tag filtering for static site
+  function initializeTagFiltering() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const selectedTag = urlParams.get('tag');
+
+    // Get all post cards and filter tags
+    const postCards = document.querySelectorAll('.post-card');
+    const filterTags = document.querySelectorAll('.filter-tag');
+
+    // Update active state of filter tags
+    filterTags.forEach(tag => {
+      const href = tag.getAttribute('href');
+      const tagName = new URLSearchParams(href.split('?')[1] || '').get('tag');
+
+      if ((selectedTag === null && href === '/garden') || (selectedTag && tagName === selectedTag)) {
+        tag.classList.add('active');
+      } else {
+        tag.classList.remove('active');
+      }
+    });
+
+    // Filter posts based on selected tag
+    if (selectedTag) {
+      postCards.forEach(card => {
+        const postTags = Array.from(card.querySelectorAll('.tag')).map(tag => tag.textContent.trim());
+
+        if (postTags.includes(selectedTag)) {
+          card.style.display = '';
+        } else {
+          card.style.display = 'none';
+        }
+      });
+    } else {
+      // Show all posts when no tag is selected
+      postCards.forEach(card => {
+        card.style.display = '';
+      });
+    }
+  }
+
+  // Run on page load
+  initializeTagFiltering();
+
+  // Re-run when navigating with browser back/forward
+  window.addEventListener('popstate', initializeTagFiltering);
+</script>


### PR DESCRIPTION
## Summary
- Fix tag filtering functionality on the garden page
- Tags are now properly highlighted when selected (underline appears)
- Posts are correctly filtered when clicking on tags

## Problem
The garden page had a tag filtering feature that wasn't working:
1. Clicking a tag didn't highlight it as selected (no underline)
2. Posts underneath weren't being filtered by the selected tag

The root cause was that the previous implementation used server-side filtering with URL query parameters (`?tag=coffee`), which doesn't work for statically generated sites.

## Solution
Implemented client-side JavaScript that:
- Reads the `tag` query parameter from the URL on page load
- Updates the `active` class on filter tags to show which one is selected
- Dynamically shows/hides post cards based on whether they contain the selected tag
- Handles browser back/forward navigation with `popstate` event

## Testing
- Built the site successfully with the new filtering script
- The JavaScript is properly minified and included in the generated HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)